### PR TITLE
Don't call the order property directly

### DIFF
--- a/src/Gateways/HeartlandGiftCards/HeartlandGiftCardOrder.php
+++ b/src/Gateways/HeartlandGiftCards/HeartlandGiftCardOrder.php
@@ -13,7 +13,7 @@ class HeartlandGiftCardOrder
 {
     public function addItemsToPostOrderDisplay($rows, $order_object)
     {
-        $order_id = $order_object->id;
+        $order_id = $order_object->get_id();
 
         $applied_gift_cards = unserialize(get_post_meta($order_id, '_securesubmit_used_card_data', true));
         $original_balance   = get_post_meta($order_id, '_securesubmit_original_reported_total', true);


### PR DESCRIPTION
WoooCommerce has deprecated calling many object properties directly. Accessing the order property `id` directly triggers the following Notice.

`Notice: id was called <strong>incorrectly</strong>. Order properties should not be accessed directly.`

FMI: https://github.com/woocommerce/woocommerce/blob/master/includes/legacy/abstract-wc-legacy-order.php#L418