### PR TITLE
Fix incorrect location to stylesheet

### DIFF
--- a/src/Gateways/HeartlandGateway.php
+++ b/src/Gateways/HeartlandGateway.php
@@ -246,7 +246,12 @@ class HeartlandGateway extends AbstractGateway {
 			$path = dirname(plugin_dir_path(__FILE__));
 
 			include_once  $path . '/../assets/frontend/HeartlandGiftFields.php';
-			wp_enqueue_style('heartland-gift-cards', $path . '/../assets/frontend/css/heartland-gift-cards.css');
+			wp_enqueue_style(
+				'heartland-gift-cards',
+				Plugin::get_url( '/../assets/frontend/css/heartland-gift-cards.css' ),
+				array(),
+				WC()->version
+			);
 		}
 	}
 

--- a/src/Gateways/HeartlandGateway.php
+++ b/src/Gateways/HeartlandGateway.php
@@ -249,7 +249,7 @@ class HeartlandGateway extends AbstractGateway {
 			include_once  $path . '/../assets/frontend/HeartlandGiftFields.php';
 			wp_enqueue_style(
 				'heartland-gift-cards',
-				Plugin::get_url( '/../assets/frontend/css/heartland-gift-cards.css' ),
+				Plugin::get_url( '/assets/frontend/css/heartland-gift-cards.css' ),
 				array(),
 				WC()->version
 			);

--- a/src/Gateways/HeartlandGateway.php
+++ b/src/Gateways/HeartlandGateway.php
@@ -8,6 +8,7 @@ use GlobalPayments\Api\Entities\Enums\GatewayProvider;
 use GlobalPayments\Api\Entities\Reporting\TransactionSummary;
 use GlobalPayments\Api\Entities\Transaction;
 use GlobalPayments\WooCommercePaymentGatewayProvider\Gateways\HeartlandGiftCards\HeartlandGiftCardOrder;
+use GlobalPayments\WooCommercePaymentGatewayProvider\Plugin;
 
 defined( 'ABSPATH' ) || exit;
 


### PR DESCRIPTION
The URI being requested from the browser was including a file system path. This fixes the URI to show the proper path relative to the plugin directory. It also adds a version number parameter to the URI for cache busting in the same manner that it is used in the AbstractGateway class.